### PR TITLE
Butterworth filter should have no imaginary part

### DIFF
--- a/butterworth_lowpass.cpp
+++ b/butterworth_lowpass.cpp
@@ -154,7 +154,7 @@ void create_butterworth_lowpass_filter(Mat& dftFilter, int radius, int order)
     flip(q3, q2, 1);
     flip(q3, q0, -1);
 
-    Mat toMerge[] = { tmp, tmp };
+	Mat toMerge[] = { tmp, Mat::zeros(tmp.size(), CV_32F) };
     merge(toMerge, 2, dftFilter);
 }
 


### PR DESCRIPTION
Line 157 in butterworth_lowpass.cpp
we read
`Mat toMerge[] = { tmp, tmp };`
I believe that we should read
`Mat toMerge[] = { tmp, Mat::zeros(tmp.size(), CV_32F) };`

as when one multiplies a DFT image by a filter, this filter should be real only, otherwise the multiplication changes the phase along with the magnitude of each pixel in the DFT.
In the current case, multiplying by {tmp, tmp} adds pi/4 to the phase in each pixel of the DFT and multiplies its magnitude by sqrt(2)*tmp.